### PR TITLE
README.md: Update manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ On Linux:
 
     git clone https://github.com/xyproto/o
     cd o
-    go build -mod=vendor
+    make
     sudo install -Dm755 o /usr/bin/o
     gzip o.1
     sudo install -Dm644 o.1.gz /usr/share/man/man1/o.1.gz


### PR DESCRIPTION
`go build -mod=vendor` does not work:

    bash-5.1$ go build -mod=vendor
    go: cannot find main module, but found .git/config in /home/emanuele6/.source_code/o
            to create a module there, run:
            go mod init

Using `make` to build the program works.

`make` will run the following command:

    cd v2 && go build -mod=vendor -v -o ../o